### PR TITLE
[Feat] 일지 작성 화면 UI 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,7 +39,8 @@
 
         <activity
             android:name=".MainActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".SplashActivity"
             android:exported="true">

--- a/app/src/main/java/com/example/slo_plo/LogWriteFragment.kt
+++ b/app/src/main/java/com/example/slo_plo/LogWriteFragment.kt
@@ -88,10 +88,15 @@ class LogWriteFragment : Fragment() {
 
         // 뒤로가기: 홈 화면으로 이동
         binding.btnLogCancel.setOnClickListener {
-            findNavController().previousBackStackEntry
-                ?.savedStateHandle
-                ?.set("showSummary", true)
-            findNavController().popBackStack()
+            showConfirmDialog(
+                title = "일지 작성 취소",
+                message = "일지 작성을 취소하고\n홈화면으로 돌아가겠습니까?"
+            ) {
+                findNavController().previousBackStackEntry
+                    ?.savedStateHandle
+                    ?.set("showSummary", true)
+                findNavController().popBackStack()
+            }
         }
 
         // 플로깅 기록 불러오기
@@ -133,7 +138,7 @@ class LogWriteFragment : Fragment() {
             val content = binding.etLogTitle.text.toString()
             val trash = binding.etLogTrash.text.toString()
             Toast.makeText(requireContext(),
-                "제목: $title\n내용: $content",
+                "제목: $title\n내용: $content 쓰레기 개수: $trash",
                 Toast.LENGTH_SHORT
             ).show()
         }

--- a/app/src/main/java/com/example/slo_plo/LogWriteFragment.kt
+++ b/app/src/main/java/com/example/slo_plo/LogWriteFragment.kt
@@ -139,8 +139,8 @@ class LogWriteFragment : Fragment() {
             val trash = binding.etLogTrash.text.toString()
 
             showConfirmDialog(
-                title = "저장 확인",
-                message = "이 내용을 저장하시겠습니까?"
+                title = "일지 저장",
+                message = "일지를 저장하시겠습니까?"
             ) {
                 Toast.makeText(
                     requireContext(),

--- a/app/src/main/java/com/example/slo_plo/LogWriteFragment.kt
+++ b/app/src/main/java/com/example/slo_plo/LogWriteFragment.kt
@@ -12,6 +12,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
@@ -19,6 +20,7 @@ import androidx.navigation.fragment.findNavController
 import com.example.slo_plo.databinding.DialogDefaultBinding
 import com.example.slo_plo.databinding.FragmentLogWriteBinding
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
@@ -99,6 +101,19 @@ class LogWriteFragment : Fragment() {
             }
         }
 
+        // 뒤로가기 버튼 클릭 이벤트를 감지하여 다이얼로그 띄우기
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            showConfirmDialog(
+                title = "일지 작성 취소",
+                message = "일지 작성을 취소하고\n홈화면으로 돌아가겠습니까?"
+            ) {
+                findNavController().previousBackStackEntry
+                    ?.savedStateHandle
+                    ?.set("showSummary", true)
+                findNavController().popBackStack()
+            }
+        }
+
         // 플로깅 기록 불러오기
         val args = requireArguments()
         val startAddr = args.getString("startAddress") ?: ""
@@ -106,10 +121,13 @@ class LogWriteFragment : Fragment() {
         val totalTime = args.getString("totalTime") ?: ""
         val totalDist = args.getString("totalDistance") ?: ""
 
-        // 날짜 설정
-        val currentDate = LocalDate.now()
-        val formatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일 E요일", Locale.KOREA)
-        binding.tvLogDate.text = currentDate.format(formatter)
+        // 날짜 및 시간 설정
+        val currentDateTime = LocalDateTime.now()
+        val formatter = DateTimeFormatter.ofPattern(
+            "yyyy년 M월 d일 E요일 HH시 mm분",
+            Locale.KOREA
+        )
+        binding.tvLogDate.text = currentDateTime.format(formatter)
 
         // 플로깅 정보 반영
         binding.tvStartAddress.text = "출발지점: $startAddr"

--- a/app/src/main/java/com/example/slo_plo/LogWriteFragment.kt
+++ b/app/src/main/java/com/example/slo_plo/LogWriteFragment.kt
@@ -135,12 +135,21 @@ class LogWriteFragment : Fragment() {
         // 저장 버튼
         binding.btnBottom.btnLogSave.setOnClickListener {
             val title = binding.etLogTitle.text.toString()
-            val content = binding.etLogTitle.text.toString()
+            val content = binding.etLogContent.text.toString()
             val trash = binding.etLogTrash.text.toString()
-            Toast.makeText(requireContext(),
-                "제목: $title\n내용: $content 쓰레기 개수: $trash",
-                Toast.LENGTH_SHORT
-            ).show()
+
+            showConfirmDialog(
+                title = "저장 확인",
+                message = "이 내용을 저장하시겠습니까?"
+            ) {
+                Toast.makeText(
+                    requireContext(),
+                    "제목: $title\n내용: $content\n쓰레기 개수: $trash",
+                    Toast.LENGTH_SHORT
+                ).show()
+
+                // Todo : DB에 저장 후 화면 전환
+            }
         }
     }
 

--- a/app/src/main/java/com/example/slo_plo/LogWriteFragment.kt
+++ b/app/src/main/java/com/example/slo_plo/LogWriteFragment.kt
@@ -1,6 +1,7 @@
 package com.example.slo_plo
 
 import android.app.Activity
+import android.app.AlertDialog
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -15,6 +16,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import com.example.slo_plo.databinding.DialogDefaultBinding
 import com.example.slo_plo.databinding.FragmentLogWriteBinding
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -146,6 +148,32 @@ class LogWriteFragment : Fragment() {
         val intent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
         galleryLauncher.launch(intent)
     }
+
+    fun showConfirmDialog(
+        title: String,
+        message: String,
+        onConfirm: () -> Unit
+    ) {
+        val binding = DialogDefaultBinding.inflate(layoutInflater)
+        val alertDialog = AlertDialog.Builder(requireContext())
+            .setView(binding.root)
+            .create()
+
+        binding.tvDefaultTitle.text = title
+        binding.tvDefaultContent.text = message
+
+        binding.btnDefaultYes.setOnClickListener {
+            onConfirm()
+            alertDialog.dismiss()
+        }
+
+        binding.btnDefaultNo.setOnClickListener {
+            alertDialog.dismiss()
+        }
+
+        alertDialog.show()
+    }
+
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/app/src/main/java/com/example/slo_plo/LogWriteFragment.kt
+++ b/app/src/main/java/com/example/slo_plo/LogWriteFragment.kt
@@ -6,11 +6,13 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
+import android.text.method.ScrollingMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.example.slo_plo.databinding.FragmentLogWriteBinding
@@ -46,7 +48,7 @@ class LogWriteFragment : Fragment() {
     ) { result ->
         if (result.resultCode == Activity.RESULT_OK) {
             val bitmap = result.data?.extras?.get("data") as? android.graphics.Bitmap
-            binding.imageSelected.apply {
+            binding.ivLogSelected.apply {
                 setImageBitmap(bitmap)
                 visibility = View.VISIBLE
             }
@@ -59,7 +61,7 @@ class LogWriteFragment : Fragment() {
     ) { result ->
         if (result.resultCode == Activity.RESULT_OK) {
             selectedImageUri = result.data?.data
-            binding.imageSelected.apply {
+            binding.ivLogSelected.apply {
                 setImageURI(selectedImageUri)
                 visibility = View.VISIBLE
             }
@@ -75,11 +77,15 @@ class LogWriteFragment : Fragment() {
         return binding.root
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        binding.etLogContent.movementMethod = ScrollingMovementMethod()
+
+
         // 뒤로가기: 홈 화면으로 이동
-        binding.buttonBack.setOnClickListener {
+        binding.btnLogCancel.setOnClickListener {
             findNavController().previousBackStackEntry
                 ?.savedStateHandle
                 ?.set("showSummary", true)
@@ -96,26 +102,21 @@ class LogWriteFragment : Fragment() {
         // 날짜 설정
         val currentDate = LocalDate.now()
         val formatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일 E요일", Locale.KOREA)
-        binding.textDate.text = currentDate.format(formatter)
+        binding.tvLogDate.text = currentDate.format(formatter)
 
         // 플로깅 정보 반영
-        binding.textStartAddress.text = "출발지점: $startAddr"
-        binding.textEndAddress.text = "도착지점: $endAddr"
-        binding.textTime.text = "시간: $totalTime"
-        binding.textDistance.text = "거리: $totalDist"
+        binding.tvStartAddress.text = "출발지점: $startAddr"
+        binding.tvEndAddress.text = "도착지점: $endAddr"
+        binding.tvLogTime.text = "시간 - $totalTime"
+        binding.tvLogDistance.text = "이동 거리 - $totalDist"
 
         // 카메라 버튼
-        binding.bottomButtons.buttonCamera.setOnClickListener {
+        binding.btnBottom.btnLogCamera.setOnClickListener {
             cameraPermissionLauncher.launch(android.Manifest.permission.CAMERA)
         }
 
-        // 갤러리 버튼
-        binding.bottomButtons.buttonGallery.setOnClickListener {
-            galleryPermissionLauncher.launch(android.Manifest.permission.READ_EXTERNAL_STORAGE)
-        }
-
         // 갤러리 권한
-        binding.bottomButtons.buttonGallery.setOnClickListener {
+        binding.btnBottom.btnLogGallery.setOnClickListener {
             val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 android.Manifest.permission.READ_MEDIA_IMAGES
             } else {
@@ -124,41 +125,16 @@ class LogWriteFragment : Fragment() {
             galleryPermissionLauncher.launch(permission)
         }
 
-
         // 저장 버튼
-        binding.bottomButtons.buttonSave.setOnClickListener {
-            val title = binding.editTitle.text.toString()
-            val content = binding.editContent.text.toString()
+        binding.btnBottom.btnLogSave.setOnClickListener {
+            val title = binding.etLogTitle.text.toString()
+            val content = binding.etLogTitle.text.toString()
+            val trash = binding.etLogTrash.text.toString()
             Toast.makeText(requireContext(),
                 "제목: $title\n내용: $content",
                 Toast.LENGTH_SHORT
             ).show()
         }
-//        // 카메라 버튼
-//        binding.buttonCamera.setOnClickListener {
-//            cameraPermissionLauncher.launch(android.Manifest.permission.CAMERA)
-//        }
-//
-////        // 갤러리 버튼
-////        binding.buttonGallery.setOnClickListener {
-////            galleryPermissionLauncher.launch(android.Manifest.permission.READ_EXTERNAL_STORAGE)
-////        }
-//        binding.buttonGallery.setOnClickListener {
-//            val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-//                android.Manifest.permission.READ_MEDIA_IMAGES
-//            } else {
-//                android.Manifest.permission.READ_EXTERNAL_STORAGE
-//            }
-//            galleryPermissionLauncher.launch(permission)
-//        }
-//
-//
-//        // 저장 버튼
-//        binding.buttonSave.setOnClickListener {
-//            val title = binding.editTitle.text.toString()
-//            val content = binding.editContent.text.toString()
-//            Toast.makeText(requireContext(), "저장됨\n제목: $title\n내용: $content", Toast.LENGTH_SHORT).show()
-//        }
     }
 
     private fun openCamera() {

--- a/app/src/main/res/drawable/ic_distance.xml
+++ b/app/src/main/res/drawable/ic_distance.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="13dp"
+    android:height="12dp"
+    android:viewportWidth="13"
+    android:viewportHeight="12">
+  <path
+      android:pathData="M-0.358,5.552L12.454,0.142L6.385,11.564L5.036,6.755L-0.358,5.552Z"
+      android:fillColor="#21699C"/>
+</vector>

--- a/app/src/main/res/drawable/ic_time.xml
+++ b/app/src/main/res/drawable/ic_time.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="15dp"
+    android:height="14dp"
+    android:viewportWidth="15"
+    android:viewportHeight="14">
+  <path
+      android:pathData="M7.502,13.1C11.092,13.1 14.003,10.303 14.003,6.853C14.003,3.403 11.092,0.606 7.502,0.606C3.911,0.606 1,3.403 1,6.853C1,10.303 3.911,13.1 7.502,13.1Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.11458"
+      android:fillColor="#00000000"
+      android:strokeColor="#12517F"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M7.502,3.105V6.853L10.103,8.102"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.11458"
+      android:fillColor="#00000000"
+      android:strokeColor="#12517F"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/button_log_write.xml
+++ b/app/src/main/res/layout/button_log_write.xml
@@ -1,44 +1,54 @@
-<LinearLayout android:id="@+id/bottom_buttons"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/btn_bottom"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:weightSum="3"
-    android:gravity="center_vertical"
-    android:padding="12dp"
-    android:background="@android:color/white"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    android:paddingTop="10dp"
+    android:background="@android:color/white">
 
-    <!-- 카메라 -->
-    <ImageButton
-        android:id="@+id/button_camera"
-        android:layout_width="0dp"
+    <!-- 카메라 버튼 -->
+    <ImageView
+        android:id="@+id/btn_log_camera"
+        android:layout_width="45dp"
         android:layout_height="48dp"
-        android:layout_weight="1"
-        android:background="@drawable/btn_round_button"
         android:src="@drawable/ic_camera"
-        android:contentDescription="카메라"
-        android:scaleType="centerInside"
-        android:padding="8dp"/>
+        android:padding="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-    <!-- 갤러리 -->
-    <ImageButton
-        android:id="@+id/button_gallery"
-        android:layout_width="0dp"
+    <!-- 갤러리 버튼 -->
+    <ImageView
+        android:id="@+id/btn_log_gallery"
+        android:layout_width="45dp"
         android:layout_height="48dp"
-        android:layout_weight="1"
-        android:background="@drawable/btn_round_button"
         android:src="@android:drawable/ic_menu_gallery"
-        android:contentDescription="갤러리"
-        android:scaleType="centerInside"
-        android:padding="8dp"/>
+        android:padding="8dp"
+        android:layout_marginStart="8dp"
+        app:layout_constraintStart_toEndOf="@id/btn_log_camera"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-    <!-- 저장 -->
-    <Button
-        android:id="@+id/button_save"
-        android:layout_width="0dp"
-        android:layout_height="48dp"
-        android:layout_weight="1"
-        android:background="@drawable/bg_square_sub_color_15"
-        android:text="저장"
-        android:textColor="@android:color/white"/>
-</LinearLayout>
+    <!-- 저장 버튼 -->
+    <FrameLayout
+        android:id="@+id/btn_log_save"
+        android:layout_width="140dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_square_support_color_10"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:fontFamily="@font/noto_sans_kr_medium"
+            android:includeFontPadding="false"
+            android:text="저장"
+            android:textColor="@color/white"
+            android:textSize="18sp"
+            android:paddingVertical="10dp"/>
+    </FrameLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_default.xml
+++ b/app/src/main/res/layout/dialog_default.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="320dp"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/tv_default_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/noto_sans_kr_medium"
+        android:includeFontPadding="false"
+        android:text="다이얼로그 제목"
+        android:textSize="18sp"
+        android:layout_marginTop="30dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_default_content"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/noto_sans_kr_regular"
+        android:includeFontPadding="false"
+        android:text="다이얼로그 내용"
+        android:textSize="15sp"
+        android:maxLines="2"
+        android:ellipsize="end"
+        android:gravity="center"
+        android:layout_marginTop="20dp"
+        android:paddingHorizontal="35dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tv_default_title" />
+
+    <!-- 버튼 영역 -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal"
+        android:paddingVertical="30dp"
+        android:paddingBottom="10dp"
+        app:layout_constraintTop_toBottomOf="@+id/tv_default_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <!-- 아니오 버튼 -->
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_default_no"
+            android:layout_width="80dp"
+            android:layout_height="40dp"
+            android:background="@drawable/bg_square_white_grey_30"
+            android:fontFamily="@font/noto_sans_kr_regular"
+            android:includeFontPadding="false"
+            android:stateListAnimator="@null"
+            android:text="아니오"
+            android:textColor="@color/text_grey"
+            android:textSize="14sp" />
+
+        <!-- 네 버튼 -->
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_default_yes"
+            android:layout_width="80dp"
+            android:layout_height="40dp"
+            android:layout_marginStart="8dp"
+            android:background="@drawable/bg_square_sub_color_30"
+            android:fontFamily="@font/noto_sans_kr_regular"
+            android:includeFontPadding="false"
+            android:stateListAnimator="@null"
+            android:text="예"
+            android:textColor="@color/white"
+            android:textSize="14sp" />
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_log_write.xml
+++ b/app/src/main/res/layout/fragment_log_write.xml
@@ -73,6 +73,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
+                android:maxLines="1"
+                android:ellipsize="end"
                 android:text="도착지점: 주소 로딩 중..."
                 android:textSize="14sp" />
 

--- a/app/src/main/res/layout/fragment_log_write.xml
+++ b/app/src/main/res/layout/fragment_log_write.xml
@@ -1,204 +1,206 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/log_write_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fillViewport="true">
+    android:paddingTop="20dp"
+    android:paddingBottom="15dp"
+    android:paddingHorizontal="24dp">
 
     <!-- 뒤로가기 버튼 -->
-    <ImageButton
-        android:id="@+id/button_back"
+    <ImageView
+        android:id="@+id/btn_log_cancel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:src="@android:drawable/ic_menu_revert"
-        android:contentDescription="뒤로가기 버튼" />
+        android:src="@drawable/ic_arrow_back"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-    <!-- 스크롤 가능한 전체 내용 -->
+    <!-- 스크롤 가능한 입력 영역 -->
     <androidx.core.widget.NestedScrollView
-        android:id="@+id/scroll_root"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="56dp"
-        android:layout_marginBottom="80dp"
-        android:padding="16dp"
-        android:fillViewport="true">
+        android:id="@+id/scroll_container"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        android:layout_marginTop="20dp"
+        app:layout_constraintTop_toBottomOf="@id/btn_log_cancel"
+        app:layout_constraintBottom_toTopOf="@id/btn_bottom"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <LinearLayout
-            android:orientation="vertical"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-            <!-- 제목 입력 -->
+            <!-- 제목 -->
             <EditText
-                android:id="@+id/edit_title"
-                android:hint="제목을 입력하세요"
-                android:textSize="20sp"
-                android:textStyle="bold"
+                android:id="@+id/et_log_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@android:color/transparent"/>
+                android:hint="제목을 입력하세요"
+                android:textSize="22sp"
+                android:fontFamily="@font/noto_sans_kr_semi_bold"
+                android:includeFontPadding="false"
+                android:background="@android:color/transparent" />
 
             <!-- 날짜 -->
             <TextView
-                android:id="@+id/text_date"
-                android:layout_marginTop="8dp"
-                android:text="날짜 로딩 중..."
-                android:textSize="16sp"
+                android:id="@+id/tv_log_date"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-
-<!--            &lt;!&ndash; 플로깅 정보 &ndash;&gt;-->
-<!--            <TextView-->
-<!--                android:id="@+id/text_info"-->
-<!--                android:layout_marginTop="8dp"-->
-<!--                android:text="출발지점: \n도착지점: \n시간: \n거리: "-->
-<!--                android:textSize="14sp"-->
-<!--                android:layout_width="match_parent"-->
-<!--                android:layout_height="wrap_content"/>-->
-            <!-- 출발지점 (한 줄, 말줄임) -->
-            <TextView
-                android:id="@+id/text_start_address"
-                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="시작지점: 서울시 영등포구 선유동 2로 7-12번지"
+                android:text="날짜 로딩 중"
                 android:textSize="14sp"
+                android:textColor="@color/text_grey"
+                android:fontFamily="@font/noto_sans_kr_regular"
+                android:includeFontPadding="false"
+                android:layout_marginTop="8dp" />
+
+            <!-- 출발/도착 주소 -->
+            <TextView
+                android:id="@+id/tv_start_address"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
                 android:maxLines="1"
-                android:ellipsize="end"/>
+                android:ellipsize="end"
+                android:text="출발지점: 주소 로딩 중..."
+                android:textSize="14sp" />
 
-            <!-- 도착지점 (한 줄, 말줄임) -->
             <TextView
-                android:id="@+id/text_end_address"
+                android:id="@+id/tv_end_address"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="종료지점: 서울시 송파구 문정동 어쩌구저쩌구 길어서 화랑초등학교 화단"
-                android:textSize="14sp"
-                android:maxLines="1"
-                android:ellipsize="end"/>
+                android:layout_marginTop="4dp"
+                android:text="도착지점: 주소 로딩 중..."
+                android:textSize="14sp" />
 
-            <!-- 시간 -->
-            <TextView
-                android:id="@+id/text_time"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="시간: "
-                android:textSize="14sp"/>
-
-            <!-- 거리 -->
-            <TextView
-                android:id="@+id/text_distance"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="거리: "
-                android:textSize="14sp"/>
-
+            <!-- 시간 & 거리 정보 박스 -->
             <LinearLayout
+                android:id="@+id/layout_log_time_distance"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:background="@drawable/bg_square_white_grey_10"
+                android:gravity="center"
                 android:orientation="horizontal"
-                android:gravity="center_vertical">
+                android:padding="20dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_end_address">
 
-                <TextView
-                    android:id="@+id/text_trash_label"
+                <ImageView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="쓰레기 개수:"
-                    android:textSize="14sp"/>
+                    android:layout_marginTop="1dp"
+                    android:src="@drawable/ic_time" />
+
+                <TextView
+                    android:id="@+id/tv_log_time"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="6dp"
+                    android:text="시간 - 00:00"
+                    android:textSize="14sp" />
+
+                <Space
+                    android:layout_width="20dp"
+                    android:layout_height="wrap_content" />
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_distance" />
+
+                <TextView
+                    android:id="@+id/tv_log_distance"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="6dp"
+                    android:layout_marginEnd="16dp"
+                    android:text="이동거리 - 0m"
+                    android:textSize="14sp" />
+            </LinearLayout>
+
+            <!-- 쓰레기 입력 -->
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="수거한 쓰레기"
+                    android:textSize="14sp" />
 
                 <EditText
-                    android:id="@+id/edit_trash_count"
-                    android:layout_width="0dp"
+                    android:id="@+id/et_log_trash"
+                    android:layout_width="48dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:layout_weight="1"
+                    android:layout_marginStart="6dp"
+                    android:hint="0"
+                    android:gravity="center"
                     android:inputType="number"
-                    android:hint="입력"
-                    android:textSize="14sp"/>
+                    android:background="@drawable/bg_square_white_grey_15"
+                    android:textSize="14sp"
+                    android:fontFamily="@font/noto_sans_kr_medium"
+                    android:includeFontPadding="false"
+                    android:paddingVertical="4dp"/>
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:text="개"
+                    android:textSize="14sp" />
             </LinearLayout>
+
+            <View
+                android:id="@+id/view_line_log"
+                android:layout_width="wrap_content"
+                android:layout_height="1dp"
+                android:layout_gravity="center_horizontal"
+                android:background="@color/line_grey"
+                android:layout_marginTop="24dp" />
 
             <!-- 선택 이미지 -->
             <ImageView
-                android:id="@+id/image_selected"
-                android:layout_marginTop="16dp"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:id="@+id/iv_log_selected"
+                android:layout_width="wrap_content"
+                android:layout_height="150dp"
                 android:visibility="gone"
-                android:adjustViewBounds="true"
-                android:scaleType="fitCenter"
-                android:maxHeight="280dp"
-                android:contentDescription="선택된 이미지"/>
+                android:scaleType="fitStart"
+                android:layout_gravity="start"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="25dp"/>
 
-            <!-- 본문 입력 -->
+            <!-- 본문 EditText -->
             <EditText
-                android:id="@+id/edit_content"
-                android:layout_marginTop="16dp"
-                android:hint="플로깅을 기록해보세요"
+                android:id="@+id/et_log_content"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:minLines="8"
+                android:hint="내용을 입력하세요"
                 android:inputType="textMultiLine"
-                android:minLines="5"
+                android:scrollbars="vertical"
+                android:fontFamily="@font/noto_sans_kr_regular"
+                android:includeFontPadding="false"
+                android:textSize="14sp"
                 android:gravity="top"
+                android:padding="8dp"
                 android:background="@android:color/transparent"/>
-
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 
-    <!-- 하단 버튼 레이아웃 include -->
+    <!-- 하단 버튼 include -->
     <include
-        android:id="@+id/bottom_buttons"
+        android:id="@+id/btn_bottom"
         layout="@layout/button_log_write"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom"/>
-
-
-<!--    &lt;!&ndash; 하단 버튼 &ndash;&gt;-->
-<!--    <LinearLayout-->
-<!--        android:id="@+id/bottom_buttons"-->
-<!--        android:layout_gravity="bottom"-->
-<!--        android:layout_width="match_parent"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        android:background="@android:color/white"-->
-<!--        android:padding="12dp"-->
-<!--        android:orientation="horizontal"-->
-<!--        android:gravity="center_vertical"-->
-<!--        android:weightSum="3">-->
-
-<!--        &lt;!&ndash; 카메라 버튼 &ndash;&gt;-->
-<!--        <ImageButton-->
-<!--            android:id="@+id/button_camera"-->
-<!--            android:layout_width="0dp"-->
-<!--            android:layout_height="48dp"-->
-<!--            android:layout_weight="1"-->
-<!--            android:background="@drawable/round_button"-->
-<!--            android:src="@drawable/ic_camera"-->
-<!--            android:scaleType="centerInside"-->
-<!--            android:contentDescription="카메라"-->
-<!--            android:padding="8dp" />-->
-
-<!--        &lt;!&ndash; 갤러리 버튼 &ndash;&gt;-->
-<!--        <ImageButton-->
-<!--            android:id="@+id/button_gallery"-->
-<!--            android:layout_width="0dp"-->
-<!--            android:layout_height="48dp"-->
-<!--            android:layout_weight="1"-->
-<!--            android:background="@drawable/round_button"-->
-<!--            android:src="@android:drawable/ic_menu_gallery"-->
-<!--            android:scaleType="centerInside"-->
-<!--            android:contentDescription="갤러리"-->
-<!--            android:padding="8dp" />-->
-
-<!--        &lt;!&ndash; 저장 버튼 &ndash;&gt;-->
-<!--        <Button-->
-<!--            android:id="@+id/button_save"-->
-<!--            android:layout_width="0dp"-->
-<!--            android:layout_height="48dp"-->
-<!--            android:layout_weight="1"-->
-<!--            android:background="@drawable/bg_square_sub_color_15"-->
-<!--            android:textColor="@android:color/white"-->
-<!--            android:text="저장" />-->
-<!--    </LinearLayout>-->
-</FrameLayout>
-
+        app:layout_constraintBottom_toBottomOf="parent"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_log_write.xml
+++ b/app/src/main/res/layout/fragment_log_write.xml
@@ -169,13 +169,14 @@
             <!-- 선택 이미지 -->
             <ImageView
                 android:id="@+id/iv_log_selected"
-                android:layout_width="wrap_content"
-                android:layout_height="150dp"
-                android:visibility="gone"
-                android:scaleType="fitStart"
-                android:layout_gravity="start"
+                android:layout_width="150dp"
+                android:layout_height="wrap_content"
                 android:layout_marginStart="10dp"
-                android:layout_marginTop="25dp"/>
+                android:layout_marginTop="25dp"
+                android:visibility="gone"
+                android:adjustViewBounds="true"
+                android:scaleType="fitCenter"
+                android:maxHeight="300dp"/>
 
             <!-- 본문 EditText -->
             <EditText


### PR DESCRIPTION
## 관련 이슈 번호

<!-- PR이 해결하는 이슈 번호를 입력하세요. -->
<!-- 예시: 'fixes #123' 또는 'closes #456' -->
#30 

## 설명

<!-- 이 PR에서 구현한 내용과 변경 사항을 간략히 설명하세요. -->
<!-- 예시: 로그인 버튼 클릭 시 화면이 전환되는 버그를 수정했습니다. -->
- 일지 화면 레이아웃을 디자인 바탕으로 수정하고 다이얼로그를 구현했습니다.

## 변경 사항

<!-- 아래 항목에 해당하는 변경 사항을 체크하여 PR의 주요 변경 사항을 명확하게 전달하세요. -->

- [X]  새로운 기능 추가
<!-- 예시: 새로운 로그인 기능을 추가 -->
- [ ]  버그 수정
<!-- 예시: 로그인 시 발생한 충돌을 수정 -->
- [ ]  코드 리팩토링
<!-- 예시: 코드 최적화를 위해 함수 리팩토링 -->
- [ ]  문서 수정
<!-- 예시: [README.md](http://readme.md/) 파일 수정 -->
- [ ]  테스트 코드 추가
<!-- 예시: 로그인 기능에 대한 단위 테스트 추가 -->
- [ ]  기타
<!-- 예시: 새로운 디렉토리 구조로 리팩토링 -->
## 스크린샷 (선택 사항)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해 주세요. -->
<!-- 예시: 버튼 클릭 시 로그인 화면으로 전환되는 모습을 보여주는 스크린샷 -->
| 일지 화면 | 취소 다이얼로그 | 저장 다이얼로그 |
|------|------|------|
| <img src="https://github.com/user-attachments/assets/f6a9ab7a-882f-4b97-af8e-b75e44df5969" width="300"/> | <img src="https://github.com/user-attachments/assets/7b83b82c-4e71-4acc-a490-ec238278c815" width="300"/> | <img src="https://github.com/user-attachments/assets/88793a39-14a8-4c86-b0be-314aeeb01a89" width="300"/> |

@kokokyng 레이아웃 수정과 다이얼로그 추가만 해두었습니다! 일지를 DB에 저장하는 것부터 구현해주시면 정말 감사하겠씁니다!! 그리고 결과 화면 올리고나서 수정한 거라 저 스크린샷과는 다른데 일지 작성 시간도 표시하도록 수정했습니단