### PR TITLE
[Feat] 지역별 플로깅 봉사활동 리스트 UI 구현 #34

### DIFF
--- a/app/src/main/java/com/example/slo_plo/RegionVolunteerFragment.kt
+++ b/app/src/main/java/com/example/slo_plo/RegionVolunteerFragment.kt
@@ -1,0 +1,4 @@
+package com.example.slo_plo
+
+class RegionVolunteerFragment {
+}

--- a/app/src/main/java/com/example/slo_plo/RegionVolunteerFragment.kt
+++ b/app/src/main/java/com/example/slo_plo/RegionVolunteerFragment.kt
@@ -1,4 +1,76 @@
 package com.example.slo_plo
 
-class RegionVolunteerFragment {
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.slo_plo.databinding.FragmentRegionVolunteerBinding
+
+class RegionVolunteerFragment : Fragment() {
+
+    private var _binding: FragmentRegionVolunteerBinding? = null
+    private val binding get() = _binding!!
+    private lateinit var recommendVolunteerAdapter: RecommendVolunteerAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentRegionVolunteerBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // 뒤로가기 동작 처리
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                val fragment = VolunteerFragment()
+                requireActivity().supportFragmentManager.beginTransaction()
+                    .replace(R.id.fragment_container_view, fragment)
+                    .commit()
+            }
+        })
+
+        // Arguments로 전달된 region 값을 받음
+        val region = arguments?.getString("region") ?: "지역명"
+        binding.btnSelectRegion.text = region
+
+        // 전달받은 지역에 맞는 봉사활동 리스트 필터링
+        val filteredList = getVolunteerList().filter { it.location == region }
+
+        // 리사이클러뷰 설정
+        recommendVolunteerAdapter = RecommendVolunteerAdapter(getVolunteerList())
+        binding.recyclerViewResionVolunteer.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = recommendVolunteerAdapter
+
+            val dividerItemDecoration = DividerItemDecoration(requireContext(), LinearLayoutManager.VERTICAL)
+            addItemDecoration(dividerItemDecoration)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun getVolunteerList(): List<RecommendVolunteer> {
+        return listOf(
+            RecommendVolunteer("길거리 청소 봉사", "도심 거리 청소를 함께해요!", "노원구", "5월 12일"),
+            RecommendVolunteer("노인복지센터 지원", "말벗이 되어 드리고 식사 보조도 해요.", "노원구", "6월 12일"),
+            RecommendVolunteer("지역 아동센터 미술 수업", "아이들과 창의력 넘치는 시간을 보내요.", "노원구", "5월 12일"),
+            RecommendVolunteer("동물 보호소 봉사", "유기동물들과 산책하며 돌봐줘요.", "노원구", "5월 12일"),
+            RecommendVolunteer("환경 보호 캠페인", "자연을 지키는 활동에 참여해요.", "노원구", "5월 12일"),
+            RecommendVolunteer("이웃 지원 봉사", "독거노인 분들에게 필요한 물품을 전달해요.", "노원구", "5월 12일"),
+            RecommendVolunteer("청소년 멘토링", "청소년들에게 진로 상담을 해줘요.", "노원구", "5월 12일"),
+            RecommendVolunteer("해변 청소 봉사", "해변에서 쓰레기를 청소해요.", "노원구", "5월 12일")
+        )
+    }
 }

--- a/app/src/main/res/drawable/btn_black_round.xml
+++ b/app/src/main/res/drawable/btn_black_round.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  
+</selector>

--- a/app/src/main/res/drawable/btn_black_round.xml
+++ b/app/src/main/res/drawable/btn_black_round.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-  
-</selector>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:padding="10dp"
+    android:shape="rectangle" >
+    <solid android:color="#FFFFFF" />
+    <stroke
+        android:width="1dp"
+        android:color="#DDDDDD"/>
+    <corners
+        android:bottomLeftRadius="120dp"
+        android:bottomRightRadius="120dp"
+        android:topLeftRadius="120dp"
+        android:topRightRadius="120dp" />
+
+</shape>

--- a/app/src/main/res/layout/fragment_region_volunteer.xml
+++ b/app/src/main/res/layout/fragment_region_volunteer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_region_volunteer.xml
+++ b/app/src/main/res/layout/fragment_region_volunteer.xml
@@ -1,6 +1,59 @@
-<?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/main_color">
+
+    <!-- 앱 아이콘 -->
+    <ImageView
+        android:id="@+id/ic_app_sloplo"
+        android:layout_width="150dp"
+        android:layout_height="150dp"
+        android:src="@drawable/ic_app_default"
+        android:layout_marginTop="20dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- 흰색 배경을 위한 컨테이너 -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/container_white_background"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@android:color/white"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="0dp"
+        app:layout_constraintTop_toBottomOf="@id/ic_app_sloplo"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <!-- 지역 선택 버튼 -->
+        <android.widget.Button
+            android:id="@+id/btn_select_region"
+            android:layout_width="wrap_content"
+            android:layout_height="37dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="16dp"
+            android:background="@drawable/btn_black_round"
+            android:text="지역명"
+            android:fontFamily="@font/noto_sans_kr_regular"
+            android:includeFontPadding="false"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <!-- RecyclerView -->
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView_resion_volunteer"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="0dp"
+            app:layout_constraintTop_toBottomOf="@id/btn_select_region"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_volunteer.xml
+++ b/app/src/main/res/layout/fragment_volunteer.xml
@@ -5,7 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/main_color"
-    tools:context=".VolunteerFragment">
+    tools:context=".VolunteerFragment"
+    android:id="@+id/fragment_container_view" >
 
     <!-- 앱 아이콘 -->
     <ImageView

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,0 +1,3 @@
+<resources>
+    <item name="selected_position" type="id"/>
+</resources>


### PR DESCRIPTION
## 관련 이슈 번호

<!-- PR이 해결하는 이슈 번호를 입력하세요. -->
<!-- 예시: 'fixes #123' 또는 'closes #456' -->
fixes #27 
closes #34 

## 설명

<!-- 이 PR에서 구현한 내용과 변경 사항을 간략히 설명하세요. -->
<!-- 예시: 로그인 버튼 클릭 시 화면이 전환되는 버그를 수정했습니다. -->

- 사용자가 BottomSheet에서 지역(구)을 선택한 뒤, 해당 지역의 봉사 활동들을 보여주는 화면으로 이동합니다.
- 선택된 지역(구)은 BottomSheet에서 어둡게 처리됩니다.
- 리스트에서 뒤로가기 버튼 클릭 시 VolunteerFragment로 돌아갑니다.
- 지역별 봉사활동 리스트는 RecyclerView로 구현되어 있으며, 현재는 모두 동일한 더미 데이터를 사용했습니다.
- 지역이 제대로 선택되었는지는 로고 아래에 있는 지역명으로 확인해주시면 되겠습니다!


## 변경 사항

<!-- 아래 항목에 해당하는 변경 사항을 체크하여 PR의 주요 변경 사항을 명확하게 전달하세요. -->

- [x]  새로운 기능 추가
<!-- 예시: 새로운 로그인 기능을 추가 -->
- [ ]  버그 수정
<!-- 예시: 로그인 시 발생한 충돌을 수정 -->
- [x]  코드 리팩토링
<!-- 예시: 코드 최적화를 위해 함수 리팩토링 -->
- [ ]  문서 수정
<!-- 예시: [README.md](http://readme.md/) 파일 수정 -->
- [ ]  테스트 코드 추가
<!-- 예시: 로그인 기능에 대한 단위 테스트 추가 -->
- [ ]  기타
<!-- 예시: 새로운 디렉토리 구조로 리팩토링 -->

## 스크린샷 (선택 사항)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해 주세요. -->
<!-- 예시: 버튼 클릭 시 로그인 화면으로 전환되는 모습을 보여주는 스크린샷 -->
|선택 전|강남 선택|지역 선택 후|
|---|---|--|
|<img src="https://github.com/user-attachments/assets/0a99935a-ba72-45be-a9a7-d952c90dadae">|<img src="https://github.com/user-attachments/assets/e3cafd78-301f-44a0-8412-2dcfceb48e9f">|<img src="https://github.com/user-attachments/assets/f725b234-78e8-40b6-bd1d-21a3111d91cc">|

